### PR TITLE
ci: run workflow on main instead of develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ name: CI
 on:
   push:
     branches:
-      - develop
+      - main
   pull_request:
 
 concurrency:
-  group: develop-qbs_ats-${{ github.event.number }}
+  group: main-qbs_ats-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
develop branch is retired; keep CI on the default main branch.